### PR TITLE
Regive moderators certain permissions

### DIFF
--- a/models/groups/moderators.yml
+++ b/models/groups/moderators.yml
@@ -173,6 +173,7 @@ minecraft_permissions:
     - ocn.punishments.warn
     - ocn.version
     - overcast.premium
+    - pgm.chat.all.receive
     - pgm.defuse
     - pgm.fullserver
     - pgm.join
@@ -207,4 +208,15 @@ minecraft_permissions:
     - setting.nick.immediate
     - setting.nick.set
     - setting.nick.unlimited
+    - skin.change    
+    - worldedit.analysis.*
+    - worldedit.drain
     - worldedit.extinguish
+    - worldedit.history.*
+    - worldedit.navigation.*
+    - worldedit.region.*
+    - worldedit.remove
+    - worldedit.selection.*
+    - worldedit.tool.info
+    - worldedit.wand
+    - worldedit.wand.toggle


### PR DESCRIPTION
- World edit perms to moderate (don't worry, it'll be limited to moderation only, unless otherwise allowed)
- Team chat viewing perm
- Skin change perm, useful for disguising better with /nick