### PR TITLE
Give advisors some in-game permissions

### DIFF
--- a/models/groups/advisors.yml
+++ b/models/groups/advisors.yml
@@ -9,7 +9,6 @@ minecraft_permissions:
   global:
   - whitelist.bypass
   - chat.admin
-  - pgm.updatemap
   - ab.banlist
   - ab.history
   - ab.reload

--- a/models/groups/advisors.yml
+++ b/models/groups/advisors.yml
@@ -4,7 +4,16 @@ badge_color: "#DF21B7"
 minecraft_flair:
   global:
     color: light_purple
-    symbol: "ά"
+    symbol: "ά "
+minecraft_permissions:
+  global:
+  - whitelist.bypass
+  - chat.admin
+  - pgm.updatemap
+  - ab.banlist
+  - ab.history
+  - ab.reload
+  - database.reload
 web_permissions:
   forum:
     5a9768ca7e43a63a3d000010: #Staff:General

--- a/models/groups/advisors.yml
+++ b/models/groups/advisors.yml
@@ -13,6 +13,7 @@ minecraft_permissions:
   - ab.history
   - ab.reload
   - database.reload
+  - lobby.restricted.access
 web_permissions:
   forum:
     5a9768ca7e43a63a3d000010: #Staff:General


### PR DESCRIPTION
- Allows them to bypass whitelist as other staff
- Allows them to access staff chat for communication purposes

- Allows them to verify banlists, punishments, and reload if necessary if a mod asks and isn't on
- Allows them to reload the database if developer/admin present cannot 

With these permissions, it is not possible to abuse them other than to carry out requests from other staff members, and does not include possible "abusable" services such as ip-checks.